### PR TITLE
Fixed getting the database name for mysql. 

### DIFF
--- a/lib/knex_tables.js
+++ b/lib/knex_tables.js
@@ -9,11 +9,13 @@ var DefaultOptions = {
 
 function getTablesNameSql(knex) {
   var client = knex.client.dialect;
+  var databaseName = knex.client.databaseName ||
+  knex.client.connectionSettings.database;
 
   switch(client) {
     case 'mysql':
       return "SELECT TABLE_NAME FROM information_schema.tables " +
-      "WHERE TABLE_SCHEMA = '" + knex.client.databaseName + "' " +
+      "WHERE TABLE_SCHEMA = '" + databaseName + "' " +
       "AND TABLE_TYPE = 'BASE TABLE'";
     case 'postgresql':
       return "SELECT tablename FROM pg_catalog.pg_tables" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-cleaner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Database cleaner for Knex.js and bookshelf.js",
   "main": "./lib/knex_cleaner.js",
   "scripts": {


### PR DESCRIPTION
Sometimes you have to get it off the connection string. I think the property I was using only works if you have already open one connection. 

I also bumped the version of the package so please run npm publish after merging and getting it locally.