### PR TITLE
Sqlite3: don't look for row key; use sqlite3 for tests

### DIFF
--- a/lib/knex_tables.js
+++ b/lib/knex_tables.js
@@ -37,7 +37,7 @@ function getSqlRows(knex, resp) {
     case 'postgresql':
       return resp.rows;
     case 'sqlite3':
-      return resp.rows;
+      return resp;
     default:
       throw new Error('Could not get the sql response from client: ' + client);
   }

--- a/test/knex_tables.js
+++ b/test/knex_tables.js
@@ -9,7 +9,7 @@ chai.use(chaiAsPromised);
 
 var knexMySQL = require('./knex_test')('mysql');
 var knexPG = require('./knex_test')('pg');
-var knexSqLite3 = require('./knex_test')('pg');
+var knexSqLite3 = require('./knex_test')('sqlite3');
 var knexTables = require('../lib/knex_tables');
 
 describe('knex_tables', function() {


### PR DESCRIPTION
This addresses an issue with using this module with sqlite3, which results in an error calling `map` on `undefined`.

It also has the tests use sqlite3 for the sqlite3 tests rather than the `pg` module.

Appreciate the great module :smile: 