### PR TITLE
Adding "RESTART IDENTITY" Would Fix PostgreSQL Sequence Issues

### DIFF
--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -51,7 +51,7 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       var quotedTableNames = tableNames.map(function(tableName) {
         return '\"' + tableName + '\"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE RESTART IDENTITY');
+      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' RESTART IDENTITY CASCADE');
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -51,7 +51,7 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       var quotedTableNames = tableNames.map(function(tableName) {
         return '\"' + tableName + '\"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
+      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE RESTART IDENTITY');
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();


### PR DESCRIPTION
Currently knex-cleaner only clears *tables*, but does nothing to the *sequences* which (may) control the IDs of the records in those tables.  As a result, after re-seeding your database you may have issues such as being able to INSERT new records, because the sequence is behind the table.

Fortunately PostgresSQL already comes with a solution for this very problem: all you need to do is add `RESTART IDENTITY` to the end of a `TRUNCATE` table command, and all associated sequences will also get reset.

This change seems to be keeping in the spirit of knex-cleaner, and I couldn't see any downside to adding it, so I just added it directly (without a "gating" config option).