### PR TITLE
Ignore knex migrations tables by default

### DIFF
--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -1,27 +1,48 @@
-'use strict';
+"use strict";
 
-var BPromise = require('bluebird');
-var _ = require('lodash');
+var BPromise = require("bluebird");
+var _ = require("lodash");
 
-var knexTables = require('../lib/knex_tables');
+var knexTables = require("../lib/knex_tables");
+var fs = require("fs");
+var path = require("path");
+var NODE_ENV = process.env.NODE_ENV || "development";
 
 var DefaultOptions = {
-  mode: 'truncate',    // Can be ['truncate', 'delete']
-  ignoreTables: []     // List of tables to not delete
+  mode: "truncate", // Can be ['truncate', 'delete']
+  ignoreTables: [] // List of tables to not delete
 };
 
 function clean(knex, passedInOptions) {
-  var options = _.defaults({}, passedInOptions, DefaultOptions);
+  var knexConfigPath = passedInOptions.knexConfigPath
+    ? passedInOptions.knexConfigPath
+    : path.resolve(process.cwd(), "knexfile.js");
 
-  return knexTables.getTableNames(knex, options)
-  .then(function(tables) {
-    if (options.mode === 'delete') {
+  if (!fs.existsSync(knexConfigPath)) {
+    throw `Unable to locate knex config at ${knexConfigPath}`;
+  }
+
+  var knexConfig = require(knexConfigPath);
+  var knexMigrationsTable =
+    knexConfig[NODE_ENV] &&
+    knexConfig[NODE_ENV].migrations &&
+    knexConfig[NODE_ENV].migrations.tableName
+      ? knexConfig[NODE_ENV].migrations.tableName
+      : "knex_migrations";
+
+  var options = _.defaults(
+    { ignoreTables: [knexMigrationsTable, `${knexMigrationsTable}_lock`] },
+    passedInOptions,
+    DefaultOptions
+  );
+
+  return knexTables.getTableNames(knex, options).then(function(tables) {
+    if (options.mode === "delete") {
       return cleanTablesWithDeletion(knex, tables, options);
     } else {
       return cleanTablesWithTruncate(knex, tables, options);
     }
   });
-
 }
 
 function cleanTablesWithDeletion(knex, tableNames, options) {
@@ -33,31 +54,35 @@ function cleanTablesWithDeletion(knex, tableNames, options) {
 function cleanTablesWithTruncate(knex, tableNames, options) {
   var client = knex.client.dialect;
 
-  switch(client) {
-    case 'mysql':
+  switch (client) {
+    case "mysql":
       return knex.transaction(function(trx) {
-        knex.raw('SET FOREIGN_KEY_CHECKS=0').transacting(trx)
-        .then(function() {
-          return BPromise.map(tableNames, function(tableName) {
-            return knex(tableName).truncate().transacting(trx);
-          });
-        })
-        .then(function() {
-          return knex.raw('SET FOREIGN_KEY_CHECKS=1').transacting(trx);
-        })
-        .then(trx.commit);
+        knex
+          .raw("SET FOREIGN_KEY_CHECKS=0")
+          .transacting(trx)
+          .then(function() {
+            return BPromise.map(tableNames, function(tableName) {
+              return knex(tableName).truncate().transacting(trx);
+            });
+          })
+          .then(function() {
+            return knex.raw("SET FOREIGN_KEY_CHECKS=1").transacting(trx);
+          })
+          .then(trx.commit);
       });
-    case 'postgresql':
+    case "postgresql":
       var quotedTableNames = tableNames.map(function(tableName) {
-        return '\"' + tableName + '\"';
+        return '"' + tableName + '"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
-    case 'sqlite3':
+      return knex.raw("TRUNCATE " + quotedTableNames.join() + " CASCADE");
+    case "sqlite3":
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();
       });
     default:
-      throw new Error('Could not get the sql to select table names from client: ' + client);
+      throw new Error(
+        "Could not get the sql to select table names from client: " + client
+      );
   }
 }
 

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -28,13 +28,14 @@ function clean(knex, passedInOptions) {
     knexConfig[NODE_ENV].migrations &&
     knexConfig[NODE_ENV].migrations.tableName
       ? knexConfig[NODE_ENV].migrations.tableName
-      : "knex_migrations";
+      : knexConfig.migrations && knexConfig.migrations.tableName
+        ? knexConfig.migrations.tableName
+        : "knex_migrations";
 
-  var options = _.defaults(
-    { ignoreTables: [knexMigrationsTable, `${knexMigrationsTable}_lock`] },
-    passedInOptions,
-    DefaultOptions
-  );
+  DefaultOptions.ignoreTables.push(knexMigrationsTable);
+  DefaultOptions.ignoreTables.push(`${knexMigrationsTable}_lock`);
+
+  var options = _.defaults({}, passedInOptions, DefaultOptions);
 
   return knexTables.getTableNames(knex, options).then(function(tables) {
     if (options.mode === "delete") {


### PR DESCRIPTION
Ignores knex migrations tables by default.
Also cleaned source code using 'prettier' defaults in consistency with #14 and #16 

As requested in #13 