### PR TITLE
add restartIdentity option for PostgresSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ knexCleaner.clean(bookshelf.knex).then(function() {
 
 var options = {
   mode: 'delete', // Valid options 'truncate', 'delete'
+  restartIdentity: true, // Used to tell PostgresSQL to reset the ID counter
   ignoreTables: ['Dont_Del_1', 'Dont_Del_2']
 }
 

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -7,6 +7,7 @@ var knexTables = require('../lib/knex_tables');
 
 var DefaultOptions = {
   mode: 'truncate',    // Can be ['truncate', 'delete']
+  restartIdentity: true, // Used to tell PostgresSQL to reset the ID counter
   ignoreTables: []     // List of tables to not delete
 };
 
@@ -51,7 +52,10 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       var quotedTableNames = tableNames.map(function(tableName) {
         return '\"' + tableName + '\"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' RESTART IDENTITY CASCADE');
+      var rawSQL = 'TRUNCATE ' + quotedTableNames.join();
+      if (options.restartIdentity) rawSQL += ' RESTART IDENTITY';
+      rawSQL += ' CASCADE';
+      return knex.raw(rawSQL);
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -51,7 +51,7 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       var quotedTableNames = tableNames.map(function(tableName) {
         return '\"' + tableName + '\"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE RESTART IDENTITY');
+      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' RESTART IDENTITY CASCADE');
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -51,7 +51,7 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       var quotedTableNames = tableNames.map(function(tableName) {
         return '\"' + tableName + '\"';
       });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
+      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE RESTART IDENTITY');
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();


### PR DESCRIPTION
#12 

Working off of the above PR, adds option to restart ID counter for PostgresSQL