### PR TITLE
For postgres, don't run truncate if no tables exist. Closes #9

### DIFF
--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -48,10 +48,13 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
         .then(trx.commit);
       });
     case 'postgresql':
-      var quotedTableNames = tableNames.map(function(tableName) {
-        return '\"' + tableName + '\"';
-      });
-      return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
+      if (_.has(tableNames, '[0]')) {
+        var quotedTableNames = tableNames.map(function(tableName) {
+          return '\"' + tableName + '\"';
+        });
+        return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
+      }
+      return;
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();


### PR DESCRIPTION
When running knex-cleaner on a Postgres DB that has no tables, we get the following error:

```
2017-12-07 21:16:33.428 CST [30002] ERROR:  relation "cascade" does not exist
2017-12-07 21:16:33.428 CST [30002] STATEMENT:  TRUNCATE  CASCADE
```

This happens because the [truncate command](https://www.postgresql.org/docs/9.1/static/sql-truncate.html) requires a table name (or names) to be given, and throws an error if none are given.

This PR just adds an if-statement to check for at least one table to be present, and if it isn't then no query is run.