### PR TITLE
Handle postgres schema

### DIFF
--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -50,8 +50,9 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       });
     case 'postgresql':
       if (_.has(tableNames, '[0]')) {
+        var pgSchema = knexTables.getPgSchema(knex);
         var quotedTableNames = tableNames.map(function(tableName) {
-          return '\"' + tableName + '\"';
+          return pgSchema + '.' + '\"' + tableName + '\"';
         });
         // return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
         let rawSQL = 'TRUNCATE ' + quotedTableNames.join();

--- a/lib/knex_tables.js
+++ b/lib/knex_tables.js
@@ -11,15 +11,7 @@ function getTablesNameSql(knex) {
   var client = knex.client.dialect;
   var databaseName = knex.client.databaseName ||
   knex.client.connectionSettings.database;
-  var pgSchema = knex.client.searchPath || 'public';
-
-  if (_.isString(pgSchema)) {
-    pgSchema = [pgSchema];
-  }
-
-  pgSchema = pgSchema.map(function(schema) {
-    return "'" + schema + "'";
-  }).join('.');
+  var pgSchema = getPgSchema(knex).replace(/"/g, "'");
 
   switch(client) {
     case 'mysql':
@@ -104,7 +96,8 @@ function getTableRowCount(knex, tableName) {
         return Number(resp[0]['count(*)']);
       });
     case 'postgresql':
-      return knex(tableName).count().then(function(resp) {
+      var pgSchema = knex.client.searchPath || 'public';
+      return knex(tableName).withSchema(pgSchema).count().then(function(resp) {
         return Number(resp[0].count);
       });
     case 'sqlite3':
@@ -116,6 +109,16 @@ function getTableRowCount(knex, tableName) {
   }
 }
 
+function getPgSchema(knex) {
+  var pgSchema = knex.client.searchPath || 'public';
+  if (_.isString(pgSchema)) {
+    pgSchema = [pgSchema];
+  }
+  return pgSchema.map(function(schema) {
+    return '\"' + schema + '\"';
+  }).join('.');
+}
+
 module.exports = {
   getTableNames: function(knex, options) {
     return getTableNames(knex, options);
@@ -125,5 +128,8 @@ module.exports = {
   },
   getDropTables: function(knex, tables) {
     return getDropTables(knex, tables);
+  },
+  getPgSchema: function(knex) {
+    return getPgSchema(knex);
   },
 };

--- a/lib/knex_tables.js
+++ b/lib/knex_tables.js
@@ -11,6 +11,15 @@ function getTablesNameSql(knex) {
   var client = knex.client.dialect;
   var databaseName = knex.client.databaseName ||
   knex.client.connectionSettings.database;
+  var pgSchema = knex.client.searchPath || 'public';
+
+  if (_.isString(pgSchema)) {
+    pgSchema = [pgSchema];
+  }
+
+  pgSchema = pgSchema.map(function(schema) {
+    return "'" + schema + "'";
+  }).join('.');
 
   switch(client) {
     case 'mysql':
@@ -19,7 +28,7 @@ function getTablesNameSql(knex) {
       "AND TABLE_TYPE = 'BASE TABLE'";
     case 'postgresql':
       return "SELECT tablename FROM pg_catalog.pg_tables" +
-      " WHERE schemaname='public';";
+      " WHERE schemaname=" + pgSchema + ";";
     case 'sqlite3':
       return "SELECT name FROM sqlite_master WHERE type='table';";
     default:


### PR DESCRIPTION
Currently there is no way to specify a non-default schema to run the cleaner against for postgres databases. This PR introduces functionality to use `knex.client.searchPath` if set, and to default to `public` otherwise.